### PR TITLE
Fixed drag proxy, which was set for moving rows between other rows (as i...

### DIFF
--- a/plugins/hgrid-draggable/hgrid-draggable.js
+++ b/plugins/hgrid-draggable/hgrid-draggable.js
@@ -424,8 +424,8 @@ this.Draggable = (function($, HGrid) {
 
       e.stopImmediatePropagation();
 
-      var top = e.pageY - $(_canvas).offset().top;
-      dd.selectionProxy.css('top', top - 5);
+      var top = e.pageY - $(_canvas).offset().top + (_grid.getOptions().rowHeight/2);
+      dd.selectionProxy.css('top', top - _grid.getOptions().rowHeight );
 
       var insertBefore = Math.max(0, Math.min(Math.round(top / _grid.getOptions().rowHeight), _grid.getDataLength()));
 

--- a/plugins/hgrid-draggable/src/hgrid-rowmovemanager.js
+++ b/plugins/hgrid-draggable/src/hgrid-rowmovemanager.js
@@ -108,8 +108,8 @@
 
       e.stopImmediatePropagation();
 
-      var top = e.pageY - $(_canvas).offset().top;
-      dd.selectionProxy.css('top', top - 5);
+      var top = e.pageY - $(_canvas).offset().top + (_grid.getOptions().rowHeight/2);
+      dd.selectionProxy.css('top', top - _grid.getOptions().rowHeight );
 
       var insertBefore = Math.max(0, Math.min(Math.round(top / _grid.getOptions().rowHeight), _grid.getDataLength()));
 


### PR DESCRIPTION
...n the original SlickGrid example), not for dropping into folders. Essentially a fix for https://github.com/CenterForOpenScience/openscienceframework.org/issues/704
